### PR TITLE
Fix safari(ios9) property checking

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,6 +1,6 @@
     var eventMatrix = [{
         // Touchable devices
-        test: ('propertyIsEnumerable' in window || 'hasOwnProperty' in document) && (window.propertyIsEnumerable('ontouchstart') || document.hasOwnProperty('ontouchstart')),
+        test: ('propertyIsEnumerable' in window || 'hasOwnProperty' in document) && (window.propertyIsEnumerable('ontouchstart') || document.hasOwnProperty('ontouchstart') || window.hasOwnProperty('ontouchstart')),
         events: {
             start: 'touchstart',
             move: 'touchmove',


### PR DESCRIPTION
On safari(ios9) doesn't work tap event on not links element (span, div)